### PR TITLE
Fix popups

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -29,7 +29,9 @@
               "src/styles.scss",
               "./node_modules/@fortawesome/fontawesome-free/css/all.min.css"
             ],
-            "scripts": []
+            "scripts": [
+              "src/scripts/p3.js"
+            ]
           },
           "configurations": {
             "github-pages": {
@@ -116,5 +118,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/pages/details-texts/details-texts.component.html
+++ b/src/app/pages/details-texts/details-texts.component.html
@@ -95,15 +95,4 @@
       </div>
     </div>
   </div>
-  <div class="details__popup" *ngIf="isDetailsPopupActive">
-    <button class="details__popup-close" (click)="handleDetailsPopupClose()">
-      <i class="fas fa-times"></i>
-    </button>
-    <h1 class="details__popup-title" [innerHTML]="detailsPopupTitle"></h1>
-    <div
-      class="details__popup-content"
-      [innerHTML]="detailsPopupContent"
-      (click)="handleDetailsClick($event)"
-    ></div>
-  </div>
 </section>

--- a/src/app/pages/details-texts/details-texts.component.html
+++ b/src/app/pages/details-texts/details-texts.component.html
@@ -66,6 +66,7 @@
           </div>
         </div>
         <div
+          id="central-panel"
           class="details__panel-main js-panel-central ls"
           [innerHTML]="middlePanel"
           (click)="handleDetailsClick($event)"

--- a/src/app/pages/details-texts/details-texts.component.ts
+++ b/src/app/pages/details-texts/details-texts.component.ts
@@ -25,9 +25,6 @@ export class DetailsTextsComponent implements OnInit {
   public middlePanel: any = "<i class='fas fa-spinner'></i>";
   public isTextPanelActive = window.innerWidth > 991 ? true : false;
   public shouldShowPaginationArrows: boolean;
-  public isDetailsPopupActive: boolean;
-  public detailsPopupContent: any;
-  public detailsPopupTitle: any;
   private paginationSliceStart: number = 0;
   private paginationSliceEnd: number = 7;
   private totalLines: number;
@@ -202,19 +199,6 @@ export class DetailsTextsComponent implements OnInit {
       middlePanelInput.innerHTML
     );
   }
-  private handlePopupDataInputHTMLConversion(text: string) {
-    const parser = new DOMParser();
-    const htmlData = parser.parseFromString(text, 'text/html');
-    const detailsPopupContentInput = htmlData.querySelector('.score_block');
-    const detailsPopupTitleInput = htmlData.querySelector('title');
-
-    this.detailsPopupTitle = this.sanitizer.bypassSecurityTrustHtml(
-      detailsPopupTitleInput.innerHTML
-    );
-    this.detailsPopupContent = this.sanitizer.bypassSecurityTrustHtml(
-      `<table>${detailsPopupContentInput.innerHTML}<table>`
-    );
-  }
 
   public handleDetailsClick(e) {
     e.preventDefault();
@@ -243,28 +227,8 @@ export class DetailsTextsComponent implements OnInit {
             .replace(/'/g, '')
             .split(' , ')
         : [];
-      const popupDataQueryParams = !!anchorEl.attributes[2]
-        ? anchorEl.attributes[2].nodeValue
-            .split('(')
-            .slice(1)
-            .join()
-            .slice(0, -1)
-            .replace(/'/g, '')
-            .split(',')
-        : [];
 
       if (anchorEl.href.includes('showexemplar')) {
-        const popupSourceQueryParams = !!anchorEl.attributes[0]
-          ? anchorEl.attributes[0].nodeValue
-              .split('(')
-              .slice(1)
-              .join()
-              .slice(0, -1)
-              .replace(/'/g, '')
-              .split(',')
-          : [];
-
-        this.getDataService.setSourceParams(popupSourceQueryParams);
         sessionStorage.setItem(
           SESSION_KEYS.METADATA_CONTENT,
           this.unsanatizedMetadataPanel
@@ -295,25 +259,9 @@ export class DetailsTextsComponent implements OnInit {
           }
 
           this.getDataService.setSubsequentGlossaryArticleParam(pureQueryParam);
-        } else if (!!anchorEl.href) {
-          this.isDetailsPopupActive = true;
-
-          this.getDataService
-            .getPopupData(
-              popupDataQueryParams[0],
-              popupDataQueryParams[1],
-              popupDataQueryParams[2]
-            )
-            .subscribe((data: any) => {
-              this.handlePopupDataInputHTMLConversion(data);
-            });
         }
       }
     }
-  }
-
-  public handleDetailsPopupClose() {
-    this.isDetailsPopupActive = false;
   }
 
   public handleMetadataClick(e) {

--- a/src/app/pages/details/details.component.scss
+++ b/src/app/pages/details/details.component.scss
@@ -236,7 +236,16 @@
       font-weight: bold;
     }
     .note {
-      display: none;
+      display: block;
+      position: fixed;
+      width: 450px;
+      height: 200px;
+      background-color: $white;
+      padding: 15px;
+      border-radius: 10px;
+      box-shadow: 0px 0px 12px 0px $grayBorder;
+      box-sizing: border-box;
+      overflow: auto;
     }
   }
 }

--- a/src/app/services/get-data/get-data.service.ts
+++ b/src/app/services/get-data/get-data.service.ts
@@ -25,9 +25,11 @@ export class GetDataService {
   private sourceURL = 'http://cdli.ucla.edu/';
 
   private baseUrl = environment.apiUrl;
-  private searchURL = `${this.baseUrl}:${environment.port}/search/`;
+  private hostUrl = `${this.baseUrl}:${environment.port}`;
+  private searchURL = `${this.hostUrl}/search/`;
   private glossaryArticleURL = `${environment.glossaryArticleURL}/neo/`;
-  private searchSuggestionsUrl = `${this.baseUrl}:${environment.port}/suggest_all/`;
+  private searchSuggestionsUrl = `${this.hostUrl}/suggest_all/`;
+  private oraccBaseUrl = `${environment.glossaryArticleURL}`;
 
   constructor(private http: HttpClient) {}
 
@@ -51,8 +53,8 @@ export class GetDataService {
     const textId = params.get('textId');
 
     const url = subProjectId
-      ? `${this.baseUrl}/${projectId}/${subProjectId}/${textId}`
-      : `${this.baseUrl}/${projectId}/${textId}`;
+      ? `${this.oraccBaseUrl}/${projectId}/${subProjectId}/${textId}`
+      : `${this.oraccBaseUrl}/${projectId}/${textId}`;
 
     return this.http.get(url, {
       responseType: 'text'
@@ -91,7 +93,7 @@ export class GetDataService {
 
   public getDetailData() {
     return this.http.get(
-      `${this.baseUrl}/${this.urlParam}/${this.language}?xis=${this.queryString}`,
+      `${this.oraccBaseUrl}/${this.urlParam}/${this.language}?xis=${this.queryString}`,
       {
         responseType: 'text'
       }
@@ -100,7 +102,7 @@ export class GetDataService {
 
   public getDetailDataPage(pageNumber) {
     return this.http.get(
-      `${this.baseUrl}/${this.urlParam}/${this.language}/${this.queryString}?page=${pageNumber}`,
+      `${this.oraccBaseUrl}/${this.urlParam}/${this.language}/${this.queryString}?page=${pageNumber}`,
       {
         responseType: 'text'
       }
@@ -140,7 +142,7 @@ export class GetDataService {
   }
 
   public getSourceData() {
-    let sourceDataURL = `${this.baseUrl}/${this.sourceParams[0]}/${this.sourceParams[1]}/html`;
+    let sourceDataURL = `${this.oraccBaseUrl}/${this.sourceParams[0]}/${this.sourceParams[1]}/html`;
 
     if (this.sourceParams[2].length > 0) {
       sourceDataURL = sourceDataURL + '?' + this.sourceParams[2];
@@ -155,7 +157,7 @@ export class GetDataService {
 
   public getPopupData(project: string, item: string, blockId: string) {
     return this.http.get(
-      `${this.baseUrl}/${project}/${item}/score?${blockId}`,
+      `${this.oraccBaseUrl}/${project}/${item}/score?${blockId}`,
       {
         responseType: 'text'
       }

--- a/src/scripts/p3.js
+++ b/src/scripts/p3.js
@@ -1,0 +1,34 @@
+function p3zoom(z) {
+}
+
+function hideNote(_e,nid) {
+    var note = document.getElementById(nid);
+    note.style.visibility = "hidden";
+    note.style.zIndex = 0;
+    return 1;
+}
+
+function showNote(e, nid) {
+    var target = e.target.getBoundingClientRect();
+    var x = target.right;
+    var y = (target.top + target.bottom)/2;
+    var note = document.getElementById(nid);
+
+    if (note.style.visibility === "visible") {
+        return;
+    }
+
+    var note_height = note.clientHeight;
+    var note_half = note_height/2;
+
+    var central_panel = document.getElementById("central-panel").getBoundingClientRect();
+    var cp_top = central_panel.top;
+    var cp_bottom = central_panel.bottom;
+
+    var posy = Math.min(Math.max(cp_top, y - note_half), cp_bottom - note_height);
+
+    note.style.top = posy + "px";
+    note.style.left = x + "px";
+    note.style.visibility = "visible";
+    note.style.zIndex = 3;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
+    "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "strict": false,
     "noImplicitOverride": true,


### PR DESCRIPTION
On the text details view, for example search ugu -> watering place -> KUB 06 -> hover over the blue "1", "2" or "3" in the middle. On production clicking these brings up a blank popup. With this change hovering gives details of the original text, like in the old oracc.